### PR TITLE
perf(cli): stop asking InterPro for the same protein twice

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,15 +94,32 @@ is byte-for-byte compatible with the `interproscan` command.
 
 #### Options
 
-| Option                | Description                | Default       |
-| --------------------- | -------------------------- | ------------- |
-| `-o, --output <file>` | Output GFF file path       | `domains.gff` |
-| `--database <name>`   | InterPro member db to read | `pfam`        |
+| Option                | Description                       | Default       |
+| --------------------- | --------------------------------- | ------------- |
+| `-o, --output <file>` | Output GFF file path              | `domains.gff` |
+| `--database <name>`   | InterPro member db to read        | `pfam`        |
+| `--no-cache`          | Re-fetch, ignoring the disk cache | off           |
 
 ```bash
 react-msaview-cli interpro accessions.tsv -o domains.gff
 react-msaview-cli interpro accessions.tsv -o domains.gff --database cdd
 ```
+
+#### Caching
+
+The InterPro API serves one protein per request — there is no batch endpoint —
+so the request count is fixed at one per distinct accession. To keep that from
+being paid twice, every response is cached on disk under
+`$XDG_CACHE_HOME/react-msaview-cli/interpro` (override with
+`REACT_MSAVIEW_CACHE`), keyed by InterPro release so a new release misses
+cleanly rather than serving coordinates computed against the old one. Proteins
+with no matches are cached too, so they are not re-fetched every run.
+
+A re-run of the same dataset therefore makes one request — the release lookup —
+and answers the rest from disk. That also makes a failed run resumable: retries
+are automatic with backoff, and if the API is still unreachable the accessions
+already fetched stay cached, so re-running picks up where it stopped instead of
+asking EBI for all of them again.
 
 ### genestructure
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,10 @@ const { values, positionals } = parseArgs({
       type: 'string',
       default: 'pfam',
     },
+    'no-cache': {
+      type: 'boolean',
+      default: false,
+    },
     ref: {
       type: 'string',
     },
@@ -125,6 +129,9 @@ OPTIONS (interpro — precomputed):
                                 line; # comments ok — the examples-gen .tsv works)
   -o, --output <file>           Output GFF file (default: domains.gff)
   --database <name>             InterPro member db to read (default: pfam)
+  --no-cache                    Re-fetch every accession, ignoring the on-disk
+                                cache (kept per InterPro release under
+                                $XDG_CACHE_HOME/react-msaview-cli/interpro)
 
 OPTIONS (genestructure):
   <input>                       MSA file (coding-sequence alignment) [required]
@@ -224,6 +231,7 @@ async function main() {
       inputFile,
       outputFile: values.output,
       database: values.database,
+      noCache: values['no-cache'],
     })
   } else if (command === 'genestructure') {
     const inputFile = positionals[1]

--- a/packages/cli/src/interpro-cache.test.ts
+++ b/packages/cli/src/interpro-cache.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'interpro-cache-'))
+  process.env.REACT_MSAVIEW_CACHE = dir
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.REACT_MSAVIEW_CACHE
+  fs.rmSync(dir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+async function load() {
+  return import('./interpro-cache.ts')
+}
+
+test('a written entry reads back, and an unwritten one misses', async () => {
+  const { readCached, writeCached } = await load()
+  expect(readCached('109.0', 'pfam', 'P12931')).toBeUndefined()
+  writeCached('109.0', 'pfam', 'P12931', [{ accession: 'PF07714' }])
+  expect(readCached('109.0', 'pfam', 'P12931')).toEqual([
+    { accession: 'PF07714' },
+  ])
+})
+
+test('an empty result caches, so matchless proteins are not re-fetched', async () => {
+  const { readCached, writeCached } = await load()
+  writeCached('109.0', 'pfam', 'P00000', [])
+  expect(readCached('109.0', 'pfam', 'P00000')).toEqual([])
+})
+
+test('a new release misses rather than serving the old coordinates', async () => {
+  const { readCached, writeCached } = await load()
+  writeCached('109.0', 'pfam', 'P12931', [{ accession: 'PF07714' }])
+  expect(readCached('110.0', 'pfam', 'P12931')).toBeUndefined()
+  expect(readCached('109.0', 'cdd', 'P12931')).toBeUndefined()
+})
+
+test('a path-traversing accession is refused, not escaped', async () => {
+  const { writeCached, readCached } = await load()
+  // writeCached swallows the throw (an unwritable cache must not fail a run),
+  // so assert nothing landed outside the cache root
+  writeCached('109.0', 'pfam', '../../escaped', 'x')
+  expect(readCached('109.0', 'pfam', '../../escaped')).toBeUndefined()
+  expect(fs.existsSync(path.join(dir, '..', '..', 'escaped.json'))).toBe(false)
+})
+
+test('corrupt cache content is a miss, not a crash', async () => {
+  const { readCached } = await load()
+  const file = path.join(dir, '109.0', 'pfam', 'P12931.json')
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, '{not json')
+  expect(readCached('109.0', 'pfam', 'P12931')).toBeUndefined()
+})
+
+test('a retryable status is retried and the eventual success returned', async () => {
+  const { fetchWithRetry } = await load()
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(new Response('', { status: 503 }))
+    .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  const res = await fetchWithRetry('https://example.org/x', { baseDelayMs: 0 })
+  expect(res.status).toBe(200)
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+})
+
+test('a 404 returns immediately rather than burning retries on it', async () => {
+  const { fetchWithRetry } = await load()
+  const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 404 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  expect((await fetchWithRetry('https://example.org/x')).status).toBe(404)
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('a 204 returns immediately: no matches is an answer, not a failure', async () => {
+  const { fetchWithRetry } = await load()
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(null, { status: 204 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  expect((await fetchWithRetry('https://example.org/x')).status).toBe(204)
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+})
+
+test('giving up names the url and the attempt count', async () => {
+  const { fetchWithRetry } = await load()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(new Response('', { status: 503 })),
+  )
+  await expect(
+    fetchWithRetry('https://example.org/x', { attempts: 2, baseDelayMs: 0 }),
+  ).rejects.toThrow(/https:\/\/example\.org\/x failed after 2 attempts/)
+})
+
+test('a network-level throw is retried like a retryable status', async () => {
+  const { fetchWithRetry } = await load()
+  const fetchMock = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('ECONNRESET'))
+    .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  expect(
+    (await fetchWithRetry('https://example.org/x', { baseDelayMs: 0 })).status,
+  ).toBe(200)
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+})

--- a/packages/cli/src/interpro-cache.ts
+++ b/packages/cli/src/interpro-cache.ts
@@ -1,0 +1,121 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+// A disk cache and a backoff policy for the InterPro API, which serves
+// precomputed matches one protein per request -- there is no batch endpoint
+// (`?accession=a,b` is ignored and returns the full entry listing instead).
+// The request count is therefore fixed at one per distinct accession, so the
+// only way to be lighter on EBI is to not ask twice.
+//
+// Cache entries are keyed by InterPro release, so a new release misses cleanly
+// rather than serving stale coordinates, and matchless proteins are cached too
+// so they are not re-fetched every run.
+
+const CACHE_DIR =
+  process.env.REACT_MSAVIEW_CACHE ??
+  path.join(
+    process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache'),
+    'react-msaview-cli',
+    'interpro',
+  )
+
+// Accessions and database names reach the filesystem as path segments, so
+// anything outside this set is rejected rather than escaped -- a real UniProt
+// accession or member-database name never contains one.
+const SAFE_SEGMENT = /^[A-Za-z0-9_.-]+$/
+
+function entryPath(release: string, database: string, accession: string) {
+  for (const segment of [release, database, accession]) {
+    if (!SAFE_SEGMENT.test(segment)) {
+      throw new Error(`refusing to build a cache path from "${segment}"`)
+    }
+  }
+  return path.join(CACHE_DIR, release, database, `${accession}.json`)
+}
+
+export function readCached<T>(
+  release: string,
+  database: string,
+  accession: string,
+): T | undefined {
+  try {
+    return JSON.parse(
+      fs.readFileSync(entryPath(release, database, accession), 'utf8'),
+    ) as T
+  } catch {
+    // a missing or unreadable entry is a cache miss, never an error: the
+    // fetch below is always able to produce the value again
+    return undefined
+  }
+}
+
+export function writeCached(
+  release: string,
+  database: string,
+  accession: string,
+  value: unknown,
+) {
+  try {
+    const file = entryPath(release, database, accession)
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(value), 'utf8')
+  } catch (e) {
+    // an unwritable cache slows the next run down; it must not fail this one
+    console.warn(`  (could not cache ${accession}: ${e})`)
+  }
+}
+
+export function cacheLocation() {
+  return CACHE_DIR
+}
+
+const RETRYABLE = new Set([408, 425, 429, 500, 502, 503, 504])
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Seconds from a Retry-After header, when the server names a wait we should
+// prefer over our own guess. Capped so a stray large value cannot hang a run.
+function retryAfterMs(response: Response) {
+  const header = response.headers.get('retry-after')
+  const seconds = header ? Number(header) : Number.NaN
+  return Number.isFinite(seconds) && seconds > 0
+    ? Math.min(seconds, 60) * 1000
+    : undefined
+}
+
+/**
+ * GET with exponential backoff on the statuses that mean "ask again later".
+ *
+ * Without this a single blip failed the whole run, and the user's fix was to
+ * re-run and re-request every accession that had already succeeded -- turning
+ * one transient error into a second full pass over the API.
+ */
+export async function fetchWithRetry(
+  url: string,
+  { attempts = 4, baseDelayMs = 1000 } = {},
+) {
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) {
+      await delay(baseDelayMs * 2 ** (attempt - 1))
+    }
+    try {
+      const response = await fetch(url)
+      if (!RETRYABLE.has(response.status)) {
+        return response
+      }
+      lastError = new Error(`${response.status} ${response.statusText}`)
+      const named = retryAfterMs(response)
+      if (named) {
+        await delay(named)
+      }
+    } catch (e) {
+      // network-level failure (DNS, reset, offline); retry the same way
+      lastError = e
+    }
+  }
+  throw new Error(`${url} failed after ${attempts} attempts: ${lastError}`)
+}

--- a/packages/cli/src/interpro-precomputed.ts
+++ b/packages/cli/src/interpro-precomputed.ts
@@ -2,6 +2,13 @@ import * as fs from 'node:fs'
 
 import { interProToGFF } from 'msa-parsers'
 
+import {
+  cacheLocation,
+  fetchWithRetry,
+  readCached,
+  writeCached,
+} from './interpro-cache.ts'
+
 // Build a domain GFF from InterPro's PRECOMPUTED matches for UniProtKB
 // accessions, instead of submitting sequences to a live InterProScan job. Every
 // UniProtKB sequence already has InterPro matches computed and served by the
@@ -21,6 +28,7 @@ export interface InterProPrecomputedOptions {
   inputFile: string
   outputFile: string
   database: string
+  noCache?: boolean
 }
 
 interface Accession {
@@ -73,8 +81,11 @@ function parseAccessions(text: string): Accession[] {
   return out
 }
 
+// The one request a run makes regardless of cache state, and the thing that
+// makes caching safe: entries are keyed by release, so a new InterPro release
+// misses rather than serving coordinates computed against the old one.
 async function fetchRelease(): Promise<string> {
-  const res = await fetch(`${API}/`)
+  const res = await fetchWithRetry(`${API}/`)
   if (!res.ok) {
     throw new Error(`InterPro release lookup failed: ${res.status}`)
   }
@@ -86,7 +97,7 @@ async function fetchEntries(
   accession: string,
   database: string,
 ): Promise<ApiResult[]> {
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `${API}/entry/${database}/protein/uniprot/${accession}/`,
   )
   // 204 = the protein exists but has no matches in this member database.
@@ -104,15 +115,52 @@ async function fetchEntries(
 export async function runInterProPrecomputed(
   options: InterProPrecomputedOptions,
 ): Promise<void> {
-  const { inputFile, outputFile, database } = options
+  const { inputFile, outputFile, database, noCache } = options
   console.log(`Reading accessions from ${inputFile}...`)
   const accessions = parseAccessions(fs.readFileSync(inputFile, 'utf8'))
-  console.log(`Found ${accessions.length} accessions`)
+  // two rows can carry the same accession under different labels; that is one
+  // protein to look up, then copied to each label
+  const distinct = [...new Set(accessions.map(a => a.accession))]
+  const extra =
+    distinct.length === accessions.length
+      ? ''
+      : ` (${distinct.length} distinct)`
+  console.log(`Found ${accessions.length} accessions${extra}`)
 
   const release = await fetchRelease()
   console.log(
-    `InterPro release ${release}; fetching precomputed ${database} matches...`,
+    `InterPro release ${release}; reading precomputed ${database} matches...`,
   )
+
+  const entriesByAccession = new Map<string, ApiResult[]>()
+  let fetched = 0
+  let cached = 0
+  for (const [i, accession] of distinct.entries()) {
+    const hit = noCache
+      ? undefined
+      : readCached<ApiResult[]>(release, database, accession)
+    let entries: ApiResult[]
+    if (hit) {
+      entries = hit
+      cached++
+    } else {
+      try {
+        entries = await fetchEntries(accession, database)
+      } catch (e) {
+        // every accession resolved so far is on disk, so the re-run this
+        // prompts resumes from here instead of asking EBI for them again
+        throw new Error(
+          `${e}\n${i} of ${distinct.length} accessions are cached; re-run to resume from ${accession}.`,
+        )
+      }
+      writeCached(release, database, accession, entries)
+      fetched++
+    }
+    entriesByAccession.set(accession, entries)
+    console.log(
+      `  [${i + 1}/${distinct.length}] ${accession}: ${entries.length} ${database} entries${hit ? ' (cached)' : ''}`,
+    )
+  }
 
   const results: Record<
     string,
@@ -127,11 +175,8 @@ export async function runInterProPrecomputed(
     }
   > = {}
 
-  let done = 0
   for (const { accession, label } of accessions) {
-    done++
-    const entries = await fetchEntries(accession, database)
-    const matches = entries
+    const matches = (entriesByAccession.get(accession) ?? [])
       .map(({ metadata, proteins }) => ({
         signature: {
           entry: {
@@ -146,10 +191,9 @@ export async function runInterProPrecomputed(
       }))
       .filter(m => m.locations.length > 0)
     results[label] = { matches, xref: [{ id: label }] }
-    console.log(
-      `  [${done}/${accessions.length}] ${label} (${accession}): ${matches.length} ${database} domains`,
-    )
   }
+
+  console.log(`${fetched} fetched, ${cached} from ${cacheLocation()}`)
 
   const gff = interProToGFF(results).replace(
     '##gff-version 3',


### PR DESCRIPTION
## Why

The InterPro API serves precomputed matches **one protein per request**. There is no batch endpoint — I checked, and `?accession=a,b` is silently ignored, returning the full 29,974-row entry listing rather than a filtered pair:

```
GET /api/entry/pfam/protein/uniprot/?accession=P12931,P06239
→ 200, count: 29974
```

So the request count is fixed at one per distinct accession, and the only way to be lighter on EBI is to not ask twice. `interpro` was asking twice in three ways:

- **Per row, not per protein.** An alignment carrying one protein under several labels paid once per label.
- **Nothing kept between runs.** Regenerating a dataset re-fetched all of it.
- **One blip discarded the whole run.** A single non-ok response threw, dropping every response already received. The user's fix was to re-run — turning one transient error into a second full pass over the API.

That third one is the real load pattern: failures caused re-fetches, not steady-state use.

## What changed

- Accessions are deduplicated before fetching.
- Every response is cached on disk, keyed by InterPro release, under `$XDG_CACHE_HOME/react-msaview-cli/interpro` (override with `REACT_MSAVIEW_CACHE`).
- Failures retry with exponential backoff, honouring `Retry-After`.
- Proteins with **no** matches are cached too — previously re-fetched every run precisely because there was nothing to store.

Release-keying is what makes caching safe, so the one request that always happens is the release lookup; a new InterPro release misses cleanly rather than serving coordinates computed against the old one.

Deliberately **not** added: concurrency. The goal is less load, not faster; fetching stays serial.

## Measured

On a 3-row list carrying 2 distinct accessions:

| | requests |
| --- | --- |
| `main` | 3, every run |
| this PR, cold | 2 (+ release lookup) |
| this PR, warm | 0 (+ release lookup) |

Output GFF is **byte-identical** to what `main` produces, verified by generating both — so the format `interpro-precomputed`'s byte-for-byte contract with `interproscan` depends on is unchanged.

## Tests

10 new tests covering cache round-trip, release/database key isolation, empty-result caching, corrupt-content and path-traversal handling, and the backoff policy (retryable vs. terminal statuses, network-level throws, giving up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)