### PR TITLE
Show a failed load instead of spinning on it forever

### DIFF
--- a/packages/lib/src/components/Loading.tsx
+++ b/packages/lib/src/components/Loading.tsx
@@ -83,7 +83,8 @@ const Reset = observer(function ({
 })
 
 const Loading = observer(function ({ model }: { model: MsaViewModel }) {
-  const { isLoading, dataInitialized, msaFilehandle, treeFilehandle } = model
+  const { isLoading, dataInitialized, error, msaFilehandle, treeFilehandle } =
+    model
   const hasPendingFilehandle = !!(msaFilehandle || treeFilehandle)
 
   return (
@@ -97,6 +98,14 @@ const Loading = observer(function ({ model }: { model: MsaViewModel }) {
           ) : (
             <MSAView model={model} />
           )
+        ) : error ? (
+          // Ahead of the spinner, because a failed load KEEPS its filehandle --
+          // only an abort clears it. So hasPendingFilehandle stays true, this
+          // fell to the spinner below, and the ImportForm that renders
+          // `model.error` was never reached: the reader got "Downloading file"
+          // and a Cancel button for as long as they were willing to watch it.
+          // Found on AlphaFold's files/msa/ prefix answering 403 to every key.
+          <Reset model={model} error={error} />
         ) : hasPendingFilehandle || isLoading ? (
           <LoadingSpinner model={model} />
         ) : (

--- a/packages/lib/src/loadErrorDisplay.test.tsx
+++ b/packages/lib/src/loadErrorDisplay.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// What a failed load LOOKS like, which is a different question from what the
+// model recorded. modelFilehandleLoaders.test.ts already pins the model half --
+// a rejected fetch sets `error` and clears `loadingMSA`, under the name "a
+// failed fetch surfaces as an error" -- and it passed throughout the whole time
+// a failed url showed the reader a spinner and nothing else.
+//
+// The error display was never missing. ImportForm renders `model.error`, and
+// the reader could not get to it: a non-abort failure KEEPS its filehandle
+// (only an abort clears it), so `hasPendingFilehandle` stayed true and
+// Loading.tsx took its spinner branch ahead of the import form, permanently.
+// Found on AlphaFold's `files/msa/` prefix answering 403 to every key in August
+// 2026 -- the view opened, said "Downloading file" with a Cancel button, and
+// was still saying it at 105s.
+import React, { act } from 'react'
+
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+
+import MSAView from './components/Loading.tsx'
+import MSAModelF from './model.ts'
+
+import type { MsaViewModel } from './model.ts'
+import type { Root } from 'react-dom/client'
+
+Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true)
+
+let container: HTMLDivElement
+let root: Root
+let model: MsaViewModel
+
+function uri(u: string) {
+  return { locationType: 'UriLocation' as const, uri: u }
+}
+
+function render() {
+  act(() => {
+    root.render(<MSAView model={model} />)
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  model = MSAModelF().create({ type: 'MsaView' })
+  model.setWidth(800)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+test('a load that fails shows the error rather than a spinner forever', () => {
+  // the state the loader leaves behind on a 403: the filehandle it could not
+  // read is still set, nothing parsed, and the error recorded
+  model.setMSAFilehandle(uri('https://example.com/blocked.a3m'))
+  model.setLoadingMSA(false)
+  model.setError(new Error('HTTP 403 fetching blocked.a3m'))
+  render()
+
+  expect(container.textContent).toContain('403')
+  expect(container.textContent).not.toContain('Loading')
+})
+
+test('a load still in flight is a spinner, not an error', () => {
+  model.setMSAFilehandle(uri('https://example.com/slow.a3m'))
+  render()
+
+  expect(model.loadingMSA).toBe(true)
+  expect(container.textContent).not.toContain('Return to import form')
+})
+
+// A guard rather than a pin: this one passes without the fix too, because with
+// no filehandle left set the view reaches the ImportForm and that already shows
+// the error. It is here so the new branch cannot quietly swallow the case.
+//
+// It also records the surprise underneath: `dataInitialized` is itself
+// `(msa || tree) && !error`, so ANY error hides a loaded alignment, including a
+// tree or gff that 404s beside a good one -- setError is shared by every
+// filehandle loader. Whether a failed OPTIONAL file should blank a good
+// alignment is a real question and a wider one, since `dataInitialized` is read
+// in several places; narrowing it is a design change rather than this fix.
+test('an error over loaded data says so instead of a bare import form', () => {
+  const loaded = MSAModelF().create({
+    type: 'MsaView',
+    msaFormat: 'fasta',
+    height: 200,
+    data: { msa: '>seq1\nACDE\n>seq2\nACDF' },
+  })
+  loaded.setWidth(800)
+  loaded.setError(new Error('domains.gff 404'))
+  act(() => {
+    root.render(<MSAView model={loaded} />)
+  })
+
+  expect(container.textContent).toContain('domains.gff 404')
+})


### PR DESCRIPTION
A URL that fails to load left the view saying **"Downloading file"**, with a Cancel button, for as long as anyone was willing to watch it.

The error display was never missing: `ImportForm` renders `model.error`. What stopped the reader reaching it is that a non-abort failure **keeps its filehandle** — only an abort clears it — so `hasPendingFilehandle` stays true and the spinner branch sits permanently ahead of the import form. This takes the error branch before it.

This is not AlphaFold-specific: it affects any bad URL, CORS failure or 404 in an MSA or tree file.

## Why the existing test didn't catch it

`modelFilehandleLoaders.test.ts` has covered this since it was written, under the name *"a failed fetch surfaces as an error"* — and it passed the whole time. It pins the model: `error` set, `loadingMSA` cleared. Both were true on screen and neither was visible. The new test mounts the component and reads what is in the DOM.

The third new test is a guard rather than a pin, and says so: with no filehandle left set the view already reaches the `ImportForm` and the error already shows, so it passes without the fix. It's there so the new branch cannot quietly swallow that case.

## Found on

AlphaFold's `/files/msa/` prefix answering 403 to every key. Every protein3d "Launch MSA view" spun instead of saying 403.

## Noted, not fixed

`dataInitialized` is `(msa || tree) && !error`, so **any** error hides a loaded alignment — including a tree or gff that 404s beside a good one, since `setError` is shared by every filehandle loader. Whether a failed *optional* file should blank a good alignment is a wider design question; `dataInitialized` is read in several places, so narrowing it is a change rather than this fix.

Based directly on `v5.10.0` rather than local `main`. 59 files / 319 tests pass, `tsc --noEmit` clean, oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)